### PR TITLE
Feature: utils functions for ast struct

### DIFF
--- a/solidhunter-lib/src/lib.rs
+++ b/solidhunter-lib/src/lib.rs
@@ -1,6 +1,18 @@
+use crate::types::{Range};
+use solc_wrapper::ast::ast::{CodeLocation, offset_from_location};
+
 pub mod linter;
 pub mod types;
 pub mod rules;
+
+pub fn offset_from_range(content: &str, range: &Range) -> usize {
+    let loc = CodeLocation {
+        line: range.start.line as usize,
+        column: range.start.character as usize,
+        length: range.length as usize,
+    };
+    offset_from_location(content, &loc)
+}
 
 #[cfg(test)]
 mod tests {

--- a/solidhunter-lib/src/rules/best_practises/line_maxlen.rs
+++ b/solidhunter-lib/src/rules/best_practises/line_maxlen.rs
@@ -15,26 +15,29 @@ impl RuleType for LineMaxLen {
     fn diagnose(&self, file: &SolidFile, files: &Vec<SolidFile>) -> Vec<LintDiag> {
         let mut res = Vec::new();
         let mut line_idx = 1;
-        
+
         for line in file.content.lines() {
             if line.len() > self.max_len {
                 res.push(LintDiag {
                     range: Range {
-                        start: Position { line: line_idx, character: self.max_len as u64}, end: Position { line: line_idx, character: line.len() as u64 } 
+                        start: Position { line: line_idx, character: self.max_len as u64},
+                        end: Position { line: line_idx, character: line.len() as u64 },
+                        length: (line.len() - self.max_len) as u64
                     },
                     message: format!("Line is too long: {}", line.len()),
                     severity: Some(self.data.severity),
                     code: None,
                     source: None,
-                    uri: file.path.clone()
+                    uri: file.path.clone(),
+                    source_file_content: file.content.clone()
                 });
             }
         }
         res
     }
 
-    
-} 
+
+}
 
 impl LineMaxLen {
     pub(crate) fn create(data: RuleEntry) -> Box<dyn RuleType> {
@@ -44,7 +47,7 @@ impl LineMaxLen {
         };
         Box::new(rule)
     }
-    
+
     pub(crate) fn create_default() -> RuleEntry {
         RuleEntry {
             id: "line-max-len".to_string(),

--- a/solidhunter-lib/src/types.rs
+++ b/solidhunter-lib/src/types.rs
@@ -38,6 +38,8 @@ pub struct LintDiag {
     pub message: String,
 
     pub uri: Uri,
+
+    pub source_file_content: String
 }
 
 
@@ -67,6 +69,7 @@ pub enum Severity {
 pub struct Range {
     pub start: Position,
     pub end: Position,
+    pub length: u64,
 }
 pub struct Location {
     pub uri: Uri,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use colored::Colorize;
 use solidhunter_lib::linter::SolidLinter;
+use solidhunter_lib::offset_from_range;
 
 use solidhunter_lib::rules::rule_impl::{create_rules_file, parse_rules};
 use solidhunter_lib::types::Severity;
@@ -44,6 +45,9 @@ fn print_diag(diag: &solidhunter_lib::types::LintDiag) {
     } else {
         padding = " ".repeat(2).to_string();
     }
+    let offset = offset_from_range(diag.source_file_content.as_str(), &diag.range);
+    let code_extract = &diag.source_file_content[offset..((offset as usize) + *&diag.range.length as usize)];
+
     println!("\n{}: {}", severity_to_string(diag.severity), diag.message);
     println!(
         "  --> {}:{}:{}",
@@ -55,9 +59,9 @@ fn print_diag(diag: &solidhunter_lib::types::LintDiag) {
         "   |");
     //TODO: add code to print
     println!(
-        "{}{}|{}", diag.range.start.line,padding, "'Add error code here'");
+        "{}{}|{}", diag.range.start.line,padding, code_extract);
     println!(
-        "   |{}{}", " ".repeat(diag.range.start.character as usize), "^".repeat(diag.range.end.character as usize - diag.range.start.character as usize));
+        "   |{}{}", " ".repeat(diag.range.start.character as usize), "^".repeat(diag.range.length as usize));
 }
 
 fn main() {


### PR DESCRIPTION
# Description

Added utils functions for src fields of ast structures and added print of wrong code in main

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] Hotfix (change that solves an urgent issue, and requires immediate attention)
- [x] New feature (hange that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

LintDiag structure has now a new field : source_file_content to let the caller display wrong code in source file

# Checklist:

- [x] I have followed the contributing guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the official documentation

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually

