### PR TITLE
Fix: removed useless fields in rules data

### DIFF
--- a/solidhunter-lib/src/rules/naming/contract_name_pascalcase.rs
+++ b/solidhunter-lib/src/rules/naming/contract_name_pascalcase.rs
@@ -5,7 +5,6 @@ use crate::types::*;
 use solc_wrapper::{ContractDefinitionChildNodes, decode_location, SourceUnit, SourceUnitChildNodes};
 
 pub struct ContractNamePascalCase {
-    enabled: bool,
     data: RuleEntry
 }
 
@@ -48,7 +47,6 @@ impl RuleType for ContractNamePascalCase {
 impl ContractNamePascalCase {
     pub(crate) fn create(data: RuleEntry) -> Box<dyn RuleType> {
         let mut rule  = ContractNamePascalCase {
-            enabled: data.data[0].parse::<bool>().unwrap(),
             data
         };
         Box::new(rule)
@@ -58,7 +56,7 @@ impl ContractNamePascalCase {
         RuleEntry {
             id: "contract-name-pascalcase".to_string(),
             severity: Severity::WARNING,
-            data: vec![true.to_string()]
+            data: vec![]
         }
     }
 }

--- a/solidhunter-lib/src/rules/naming/func_name_camelcase.rs
+++ b/solidhunter-lib/src/rules/naming/func_name_camelcase.rs
@@ -5,7 +5,6 @@ use crate::types::*;
 use solc_wrapper::{ContractDefinitionChildNodes, decode_location, FunctionDefinitionKind, SourceUnit, SourceUnitChildNodes};
 
 pub struct FuncNameCamelCase {
-    enabled: bool,
     data: RuleEntry
 }
 
@@ -56,7 +55,6 @@ impl RuleType for FuncNameCamelCase {
 impl FuncNameCamelCase {
     pub(crate) fn create(data: RuleEntry) -> Box<dyn RuleType> {
         let mut rule  = FuncNameCamelCase {
-            enabled: data.data[0].parse::<bool>().unwrap(),
             data
         };
         Box::new(rule)
@@ -66,7 +64,7 @@ impl FuncNameCamelCase {
         RuleEntry {
             id: "func-name-camelcase".to_string(),
             severity: Severity::WARNING,
-            data: vec![true.to_string()]
+            data: vec![]
         }
     }
 }

--- a/solidhunter-lib/src/rules/naming/func_param_name_camelcase.rs
+++ b/solidhunter-lib/src/rules/naming/func_param_name_camelcase.rs
@@ -5,7 +5,6 @@ use crate::types::*;
 use solc_wrapper::{ContractDefinitionChildNodes, decode_location, SourceUnit, SourceUnitChildNodes};
 
 pub struct FuncParamNameCamelcase {
-    enabled: bool,
     data: RuleEntry
 }
 
@@ -58,7 +57,6 @@ impl RuleType for FuncParamNameCamelcase {
 impl FuncParamNameCamelcase {
     pub(crate) fn create(data: RuleEntry) -> Box<dyn RuleType> {
         let mut rule  = FuncParamNameCamelcase {
-            enabled: data.data[0].parse::<bool>().unwrap(),
             data
         };
         Box::new(rule)
@@ -68,7 +66,7 @@ impl FuncParamNameCamelcase {
         RuleEntry {
             id: "func-param-name-camelcase".to_string(),
             severity: Severity::WARNING,
-            data: vec![true.to_string()]
+            data: vec![]
         }
     }
 }


### PR DESCRIPTION
# Description

Removed useless (mainly enabled) fields in rules structures and default config

# Changes include

- [ ] Bugfix (change that solves an issue)
- [ ] New feature (change that adds functionality)
- [x] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

There is no more "enabled" field in config file for the affected rules

# Checklist:

- [x] I have followed the contributing guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the official documentation

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually