### PR TITLE
fix(ast): `split('\n')` instead of built-in `lines()`

### DIFF
--- a/solc-wrapper/src/ast/ast.rs
+++ b/solc-wrapper/src/ast/ast.rs
@@ -1457,9 +1457,9 @@ pub fn get_line_from_offset(content: &str, offset: usize) -> (usize, usize) {
     let mut nb_line = 1;
     let mut tmp = offset;
 
-    for line in content.lines() {
+    for line in content.split('\n') {
         if line.len() < tmp {
-            tmp -= (line.len() + 1);
+            tmp -= line.len() + 1;
             nb_line += 1;
             continue;
         }


### PR DESCRIPTION
# Description

Fixed invalid AST line ending detection with Windows line ending.

# Changes include

- [X] Bugfix (change that solves an issue)
- [ ] New feature (change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Breaking changes

Please complete this section if any breaking changes have been made, otherwise delete it

# Checklist:

- [X] I have followed the contributing guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the official documentation

## Testing

- [ ] I have tested this code with the official test suite
- [X] I have tested this code manually