### PR TITLE
Feature: reason string rule

### DIFF
--- a/solc-wrapper/src/ast/ast.rs
+++ b/solc-wrapper/src/ast/ast.rs
@@ -265,21 +265,21 @@ pub enum Expression {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum Statement {
-    Block(Box<Block>),
-    Break(Box<Break>),
-    Continue(Box<Continue>),
-    DoWhileStatement(Box<DoWhileStatement>),
-    EmitStatement(Box<EmitStatement>),
-    ExpressionStatement(Box<ExpressionStatement>),
+    VariableDeclarationStatement(Box<VariableDeclarationStatement>),
     ForStatement(Box<ForStatement>),
     IfStatement(Box<IfStatement>),
-    PlaceholderStatement(Box<PlaceholderStatement>),
+    DoWhileStatement(Box<DoWhileStatement>),
     Return(Box<Return>),
-    RevertStatement(Box<RevertStatement>),
     TryStatement(Box<TryStatement>),
-    UncheckedBlock(Box<UncheckedBlock>),
-    VariableDeclarationStatement(Box<VariableDeclarationStatement>),
     WhileStatement(Box<WhileStatement>),
+    UncheckedBlock(Box<UncheckedBlock>),
+    EmitStatement(Box<EmitStatement>),
+    RevertStatement(Box<RevertStatement>),
+    ExpressionStatement(Box<ExpressionStatement>),
+    Block(Box<Block>),
+    Continue(Box<Continue>),
+    Break(Box<Break>),
+    PlaceholderStatement(Box<PlaceholderStatement>),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/solidhunter-lib/src/rules/best_practises/mod.rs
+++ b/solidhunter-lib/src/rules/best_practises/mod.rs
@@ -6,12 +6,14 @@ pub mod code_complexity;
 pub mod line_maxlen;
 pub mod max_states_count;
 pub mod function_max_lines;
+pub mod reason_string;
 
 // List all rules
 
 use crate::rules::best_practises::code_complexity::CodeComplexity;
 use crate::rules::best_practises::line_maxlen::LineMaxLen;
 use crate::rules::best_practises::max_states_count::MaxStatesCount;
+use crate::rules::best_practises::reason_string::ReasonString;
 use crate::rules::best_practises::function_max_lines::FunctionMaxLines;
 use crate::rules::RuleBuilder;
 
@@ -22,6 +24,7 @@ pub fn create_default_rules() -> Vec<RuleEntry> {
     rules.push(CodeComplexity::create_default());
     rules.push(MaxStatesCount::create_default());
     rules.push(FunctionMaxLines::create_default());
+    rules.push(ReasonString::create_default());
 
     rules
 }
@@ -33,6 +36,7 @@ pub fn create_rules() -> HashMap<String, fn(RuleEntry) -> Box<dyn RuleType>> {
     rules.insert("code-complexity".to_string(), CodeComplexity::create);
     rules.insert(MaxStatesCount::RULE_ID.to_string(), MaxStatesCount::create);
     rules.insert(FunctionMaxLines::RULE_ID.to_string(), FunctionMaxLines::create);
+    rules.insert(reason_string::RULE_ID.to_string(), ReasonString::create);
 
     rules
 }

--- a/solidhunter-lib/src/rules/best_practises/reason_string.rs
+++ b/solidhunter-lib/src/rules/best_practises/reason_string.rs
@@ -1,0 +1,101 @@
+use solc_wrapper::{NodeType, Expression, decode_location};
+use solc_wrapper::ast::utils::{get_all_nodes_by_type, self};
+
+use crate::linter::SolidFile;
+use crate::rules::types::{RuleEntry, RuleType};
+use crate::types::{LintDiag, Range, Position, Severity};
+
+pub const RULE_ID: &str = "reason-string";
+const DEFAULT_SEVERITY: Severity = Severity::WARNING;
+const DEFAULT_MESSAGE: &str = "Require or revert statement must have a reason string and check that each reason string is at most N characters long.";
+
+// Specific
+const DEFAULT_LENGTH: u32 = 32;
+
+
+pub struct ReasonString {
+    max_length: u32,
+    data: RuleEntry
+}
+
+impl RuleType for ReasonString {
+
+    fn diagnose(&self, file: &SolidFile, files: &Vec<SolidFile>) -> Vec<LintDiag> {
+        let mut res = Vec::new();
+
+        let nodes = get_all_nodes_by_type(file.data.clone(), NodeType::FunctionCall);
+        for i in &nodes {
+            match i {
+                utils::Nodes::FunctionCall(j) => {
+                    match &j.expression {
+                        Expression::Identifier(v) => {
+                            if v.name == "require" {
+                                if j.arguments.len() != 2 {
+                                    let location = decode_location(&j.src, &file.content);
+                                    let diag = LintDiag {
+                                        range: Range {
+                                            start: Position { line: location.0.line as u64, character: location.0.column as u64 },
+                                            end: Position { line: location.1.line as u64, character: location.1.column as u64 },
+                                            length: location.0.length as u64
+                                        },
+                                        message: format!("reason-string: A require statement must have a reason string"),
+                                        severity: Some(self.data.severity),
+                                        code: None,
+                                        source: None,
+                                        uri: file.path.clone(),
+                                        source_file_content: file.content.clone(),
+                                    };
+                                    res.push(diag);
+                                }
+                            } else if v.name == "revert" {
+                                if j.arguments.len() == 0 {
+                                    let location = decode_location(&j.src, &file.content);
+                                    let diag = LintDiag {
+                                        range: Range {
+                                            start: Position { line: location.0.line as u64, character: location.0.column as u64 },
+                                            end: Position { line: location.1.line as u64, character: location.1.column as u64 },
+                                            length: location.0.length as u64
+                                        },
+                                        message: format!("reason-string: A revert statement must have a reason string"),
+                                        severity: Some(self.data.severity),
+                                        code: None,
+                                        source: None,
+                                        uri: file.path.clone(),
+                                        source_file_content: file.content.clone(),
+                                    };
+                                    res.push(diag);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+        res
+    }
+
+}
+
+// require = Identifier + name = require
+// revert = Identifier + name = revert
+
+
+impl ReasonString {
+    pub fn create(data: RuleEntry) -> Box<dyn RuleType> {
+        let mut rule  = ReasonString {
+            max_length: data.data[0].parse::<u32>().unwrap(),
+            data
+        };
+        Box::new(rule)
+    }
+
+    pub fn create_default() -> RuleEntry {
+        RuleEntry {
+            id: RULE_ID.to_string(),
+            severity: DEFAULT_SEVERITY,
+            data: vec![DEFAULT_LENGTH.to_string()]
+        }
+    }
+}

--- a/solidhunter-lib/src/rules/naming/use_forbidden_name.rs
+++ b/solidhunter-lib/src/rules/naming/use_forbidden_name.rs
@@ -18,8 +18,6 @@ impl RuleType for UseForbiddenName {
 
         let nodes = get_all_nodes_by_type(file.data.clone(), NodeType::VariableDeclaration);
 
-        println!("{:?}", file.data);
-
         for node in nodes {
             let var = match node {
                 Nodes::VariableDeclaration(var) => var,


### PR DESCRIPTION
# Description

Adding the ordering rule that warn when file and contract are not ordered

# Changes include

- [ ] Bugfix (change that solves an issue)
- [x] New feature (change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist:

- [x] I have followed the contributing guidelines
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the official documentation

## Testing

- [ ] I have tested this code with the official test suite
- [x] I have tested this code manually